### PR TITLE
Change to the data passed into the can-patch and cannot-patch

### DIFF
--- a/lib/assert/can-patch.js
+++ b/lib/assert/can-patch.js
@@ -1,12 +1,12 @@
 const assert = require('assert')
 
-module.exports = function assertCanPatch (service, recordToPatch, attributeToPatch, newValue, done) {
-  const { id } = service
-  const itemId = typeof recordToPatch[id] === 'number' ? recordToPatch[id] : recordToPatch[id].toString()
-
-  return service.patch(itemId, { [attributeToPatch]: newValue })
+module.exports = function assertCanPatch (service, itemId, data, done) {
+  const id = typeof itemId === 'number' ? itemId : itemId.toString()
+  return service.patch(id, data)
     .then(response => {
-      assert(response[attributeToPatch] === newValue, `can patch ${attributeToPatch} attribute`)
+      Object.keys(data).forEach(item => {
+        assert(response[item] === data[item], `can patch ${item} attribute`)
+      })
       done()
     })
     .catch(done)

--- a/lib/assert/can-patch.js
+++ b/lib/assert/can-patch.js
@@ -4,7 +4,9 @@ module.exports = function assertCanPatch (service, itemId, data, done) {
   const id = typeof itemId === 'number' ? itemId : itemId.toString()
   return service.patch(id, data)
     .then(response => {
-      assert.deepEqual(response[attributeToPatch], newValue, `can patch ${attributeToPatch} attribute`)
+      Object.keys(data).forEach(item => {
+        assert.deepEqual(response[item], data[item], `can patch ${item} attribute`)
+      })
       done()
     })
     .catch(done)

--- a/lib/assert/cannot-patch.js
+++ b/lib/assert/cannot-patch.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 
 module.exports = function assertCannotPatch (service, itemId, data, errorClassName, errorMessage, done) {
   const id = typeof itemId === 'number' ? itemId : itemId.toString()
-
   return service.patch(id, data)
     .then(response => {
       const attributeToPatch = Object.keys(data)

--- a/lib/assert/cannot-patch.js
+++ b/lib/assert/cannot-patch.js
@@ -1,11 +1,11 @@
 const assert = require('assert')
 
-module.exports = function assertCannotPatch (service, recordToPatch, attributeToPatch, newValue, errorClassName, errorMessage, done) {
-  const { id } = service
-  const itemId = typeof recordToPatch[id] === 'number' ? recordToPatch[id] : recordToPatch[id].toString()
+module.exports = function assertCannotPatch (service, itemId, data, errorClassName, errorMessage, done) {
+  const id = typeof itemId === 'number' ? itemId : itemId.toString()
 
-  return service.patch(itemId, { [attributeToPatch]: newValue })
+  return service.patch(id, data)
     .then(response => {
+      const attributeToPatch = Object.keys(data)
       done(`should not have been able to patch ${attributeToPatch} attribute`)
     })
     .catch(error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3408,15 +3408,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3426,6 +3417,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,7 +128,7 @@ describe('feathers-mocha-utils', () => {
           .then(response => {
             assert(response.test === false, 'should have patched properly')
 
-            return utils.assert.canPatch(service, response, 'test1', true, done)
+            return utils.assert.canPatch(service, response.id, { test1: true }, done)
           })
           .catch(done)
       })
@@ -141,7 +141,7 @@ describe('feathers-mocha-utils', () => {
           .then(response => {
             assert(response.test === false, 'should have patched properly')
 
-            return utils.assert.cannotPatch(service, response, 'noTouchy', true, 'bad-request', 'you cannot patch noTouchy', done)
+            return utils.assert.cannotPatch(service, response.id, { noTouchy: true }, 'bad-request', 'you cannot patch noTouchy', done)
           })
           .catch(done)
       })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,7 +147,7 @@ describe('feathers-mocha-utils', () => {
         service.get(item.id)
           .then(response => {
             assert(response, 'should have gotten record')
-            return utils.assert.canPatch(service, response, 'testDeep', deepData, done)
+            return utils.assert.canPatch(service, response.id, { testDeep: deepData }, done)
           })
           .catch(done)
       })


### PR DESCRIPTION
Changed the format for the data, so you can pass an object in instead of an attribute and value.

Also rather than passing in the whole item, I changed it to just be the `itemId`, as I was seeing an issue where destructuring the `id` from the service was returning undefined.