### PR TITLE
can-patch accounts for object comparison

### DIFF
--- a/lib/assert/can-patch.js
+++ b/lib/assert/can-patch.js
@@ -6,7 +6,7 @@ module.exports = function assertCanPatch (service, recordToPatch, attributeToPat
 
   return service.patch(itemId, { [attributeToPatch]: newValue })
     .then(response => {
-      assert(response[attributeToPatch] === newValue, `can patch ${attributeToPatch} attribute`)
+      assert.deepEqual(response[attributeToPatch], newValue, `can patch ${attributeToPatch} attribute`)
       done()
     })
     .catch(done)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,7 +114,7 @@ describe('feathers-mocha-utils', () => {
 
     describe('canPatch & cannotPatch', function () {
       before(function () {
-        return app.service('patch-service').create({ test: true, test1: false })
+        return app.service('patch-service').create({ test: true, test1: false, testDeep: {} })
           .then(response => {
             this.item = response
           })
@@ -129,6 +129,25 @@ describe('feathers-mocha-utils', () => {
             assert(response.test === false, 'should have patched properly')
 
             return utils.assert.canPatch(service, response, 'test1', true, done)
+          })
+          .catch(done)
+      })
+
+      it('properly passes deep check when the user can patch', function (done) {
+        const item = this.item
+        const service = app.service('patch-service')
+        const deepData = {
+          turtles: ['all the way down'],
+          frequency: {
+            nature: '432 Hz',
+            love: '528 Hz'
+          }
+        }
+
+        service.get(item.id)
+          .then(response => {
+            assert(response, 'should have gotten record')
+            return utils.assert.canPatch(service, response, 'testDeep', deepData, done)
           })
           .catch(done)
       })


### PR DESCRIPTION
Closes #1 - allow object comparison by using assert.deepEqual