### PR TITLE
Adding support for testing 404 not found errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Several assertion utilities are included.  Check out example usage in the [test 
 - `disableMultiItemChange`
 - `notImplemented`
 - `forbidden`
+-  `notFound`
 - `canPatch`
 - `cannotPatch`
 
@@ -77,6 +78,7 @@ describe('Todo Service - Unauthenticated Client', function () {
 - `utils.assert.disableMultiItemChange(service, method, done)`
 - `utils.assert.notImplemented(service, method, done)`
 - `utils.assert.forbidden(service, method, done)`
+- `utils.assert.notFound(service, method, done)`
 - `utils.assert.canPatch(service, recordToPatch, attributeToPatch, newValue, done)`
 - `utils.assert.cannotPatch(service, recordToPatch, attributeToPatch, newValue, errorClassName, errorMessage, done)`
 

--- a/lib/assert/index.js
+++ b/lib/assert/index.js
@@ -9,6 +9,7 @@ module.exports = {
   disableMultiItemChange,
   notImplemented: makeAssertion('not-implemented'),
   forbidden: makeAssertion('forbidden'),
+  notFound: makeAssertion('not-found'),
   canPatch,
   cannotPatch
 }

--- a/test/app.js
+++ b/test/app.js
@@ -23,6 +23,7 @@ const app = feathers()
   .use('disable-multi-item-change', memory())
   .use('not-implemented', memory())
   .use('forbidden', memory())
+  .use('not-found', memory())
   .use('patch-service', memory())
 
 app.service('method-not-allowed').hooks({
@@ -60,6 +61,16 @@ app.service('not-implemented').hooks({
     create: [
       context => {
         return Promise.reject(new errors.NotImplemented())
+      }
+    ]
+  }
+})
+
+app.service('not-found').hooks({
+  before: {
+    create: [
+      context => {
+        return Promise.reject(new errors.NotFound())
       }
     ]
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,7 @@ describe('feathers-mocha-utils', () => {
       'disableMultiItemChange',
       'notImplemented',
       'forbidden',
+      'notFound',
       'canPatch',
       'cannotPatch'
     ]
@@ -91,6 +92,22 @@ describe('feathers-mocha-utils', () => {
             assert(error.code === 501, 'should get 501 error')
 
             return utils.assert.notImplemented(service, 'create', done)
+          })
+          .catch(done)
+      })
+    })
+
+    describe('notFound', function () {
+      it('properly passes with not-found response', function (done) {
+        const service = app.service('not-found')
+
+        service.create({})
+          .then(done)
+          .catch(error => {
+            assert(error.className === 'not-found', 'should get not-found error')
+            assert(error.code === 404, 'should get 404 error')
+
+            return utils.assert.notFound(service, 'create', done)
           })
           .catch(done)
       })


### PR DESCRIPTION
Adds support for easily testing 404 errors.

Deliberate 404s are useful for services that are server-side only, so if someone comes knocking at the url they won't see a light on behind it.

Example: a service that sends emails to users